### PR TITLE
optimize `islice` by taking only until maximum index multiple of `step`

### DIFF
--- a/src/itertools.ts
+++ b/src/itertools.ts
@@ -215,8 +215,7 @@ export function islice<T>(
   let i = skip(iterable, start);
   if (stop !== null) {
     const length = stop - start;
-    const maxMultipleIdx = Math.floor((length - 1 + step) / step);
-    i = take(i, step * (maxMultipleIdx - 1) + 1);
+    i = take(i, length - ((length - 1) % step));
   }
 
   return nth(i, step);


### PR DESCRIPTION
Consider the following example:
```ts
function* slowIterable() {
  let i = 0;
  while (true) {
    console.log(`Calculating for ${i}`);
    // <heavy cpu work>
    yield i++;
  }
}

const sliced = islice(slowIterable(), 0, 10, 5);

console.log(Array.from(sliced)); // [0, 5]
```
This seems to work however we can safely optimize by skipping all elements after 5

Current behaviour:
```
$ node current.mjs
Calculating for 0
Calculating for 1
Calculating for 2
Calculating for 3
Calculating for 4
Calculating for 5
Calculating for 6
Calculating for 7
Calculating for 8
Calculating for 9
Calculating for 10 // Note: this is a result of another bug fixed in this PR (talked about below)
[ 0, 5 ]
```
Optimized behaviour:
```
$ node optimized.mjs
Calculating for 0
Calculating for 1
Calculating for 2
Calculating for 3
Calculating for 4
Calculating for 5
[ 0, 5 ]
```
You may ask yourself why is `Calculating for 10` here when we only want elements from index 0 up until and including 9. Well this is because of this piece of code:
```ts
for (const [i, value] of enumerate(iterable)) {
    if (i < start) continue;
    if (stop !== null && i >= stop) break; // we wait for a full iteration to stop
    if ((i - start) % step === 0) {
      yield value;
    }
    // we should have stopped here when `i` was equal to 9
  }
```
This is fixed however by use of this function:
```ts
function* take<T>(iterable: Iterable<T>, n: number): Iterable<T> {
  if (n <= 0) return;

  for (const item of iterable) {
    yield item;
    n--;
    if (n <= 0) return;
  }
}
```