### PR TITLE
`Reduce` does not work correctly with lazy iterable.

### DIFF
--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -264,11 +264,11 @@ function reduce3<T, O>(iterable: Iterable<T>, reducer: (agg: O, item: T, index: 
 
 function reduce2<T>(iterable: Iterable<T>, reducer: (agg: T, item: T, index: number) => T): T | undefined {
   const it = iter(iterable);
-  const start = find(it);
-  if (start === undefined) {
+  const start = it.next();
+  if (start.done) {
     return undefined;
   } else {
-    return reduce3(it, reducer, start);
+    return reduce3(it, reducer, start.value);
   }
 }
 

--- a/test/builtins.test.ts
+++ b/test/builtins.test.ts
@@ -351,6 +351,14 @@ describe("reduce", () => {
     expect(reduce([13, 2, 3, 4], firstOne)).toEqual(13);
     expect(reduce([undefined, null, 1, 2, 3, 4], firstOne)).toEqual(undefined);
   });
+  it("reduce on iterable (lazily-evaluated)", () => {
+    function* myLazyList() {
+      yield 1;
+      yield 2;
+      yield 3;
+    }
+    expect(reduce(myLazyList(), adder)).toEqual(6);
+  });
 });
 
 describe("sorted", () => {


### PR DESCRIPTION
If a lazy iterable is passed to `reduce`, the current implementation will only get the first element instead of consuming every elements. This mean the previous implementation will fail the following test:

https://github.com/quangloc99/itertools/blob/df7b876b48c78cb2b9e8779d59d6b1388467cc43/test/builtins.test.ts#L354-L360

The reason lies on the [`iterator` protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of) with `for ... of ...` loop. Here is the quote from `MDN`:

> If the for...of loop exited early (e.g. a break statement is encountered or an error is thrown), the [return()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterator_protocol) method of the iterator is called to perform any cleanup.

In the current implementation, `find` is called. Inside `find`, a `for ... of ...` loop is used. And after the function, the iterable was **destroyed**. Therefore only the very first element was considered.

This causes a lot of trouble when using `reduce` with the others lazy function. In my case, I used `reduce` with `flatmap` and I got no idea why I got incorrect result :pray:.