### PR TITLE
Update index.ts to export `repeat` from `itertools`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ export {
   izipMany,
   izipLongest,
   permutations,
+  repeat,
   takewhile,
   zipLongest,
   zipMany,


### PR DESCRIPTION
It looks like the `repeat<T>` function is intended to be exported, so this PR exports it.